### PR TITLE
fix(graph): make reverse-dependency resolution import-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- `impact_analysis` / `assess_risk` reverse-dependency resolution is now import-aware: a reference to an unqualified name is attributed only to the definition the caller imports, not to every same-named definition. Deflates inflated `dependent_files` blast radius for common names (framework lifecycle methods, shared utilities, trait-method implementations).
+
 ## [0.12.0] - 2026-06-13
 
 ### Added

--- a/crates/graph/src/query.rs
+++ b/crates/graph/src/query.rs
@@ -1711,11 +1711,46 @@ fn build_impact_summary(entries: &[ImpactEntry]) -> ImpactSummary {
 }
 
 fn references_for_symbol(db: &Database, sym: &Symbol) -> Result<Vec<Reference>> {
-    if sym.qualified_name != sym.name {
-        return db.find_references(&sym.qualified_name, None);
-    }
+    let key = if sym.qualified_name != sym.name {
+        &sym.qualified_name
+    } else {
+        &sym.name
+    };
+    let raw = db.find_references(key, None)?;
 
-    db.find_references(&sym.name, None)
+    // Import-aware reverse resolution. `find_references` matches by
+    // `to_name_tail`, so an unqualified name fans out to *every* same-named
+    // definition — a call to one class's `getAttributes` was counted toward
+    // all of them, inflating the reverse blast radius that `impact_analysis`
+    // and `assess_risk` read. `resolve_callee_definitions` already filters
+    // candidates by the caller file's imports (the forward path); routing each
+    // candidate reference back through it makes a reverse edge exist iff the
+    // matching forward edge does. Unique names short-circuit in the resolver
+    // (≤1 candidate), so distinctively-named symbols are untouched — only
+    // genuinely ambiguous names get import-filtered. Resolutions are cached per
+    // `(from_file, to_name)` because a hot symbol's callers repeat both.
+    let mut out = Vec::with_capacity(raw.len());
+    let mut cache: HashMap<(String, String), Vec<Symbol>> = HashMap::new();
+    for r in raw {
+        let cache_key = (r.from_file.clone(), r.to_name.clone());
+        if !cache.contains_key(&cache_key) {
+            let resolved = resolve_callee_definitions(db, &r.from_file, &r.to_name)?;
+            cache.insert(cache_key.clone(), resolved);
+        }
+        if cache[&cache_key].iter().any(|s| same_symbol_def(s, sym)) {
+            out.push(r);
+        }
+    }
+    Ok(out)
+}
+
+/// Identity test for two `Symbol`s naming the same definition. `Symbol` carries
+/// no stable id, so we key on the triple that uniquely locates a definition:
+/// file, qualified name, and start line.
+fn same_symbol_def(a: &Symbol, b: &Symbol) -> bool {
+    a.file_path == b.file_path
+        && a.qualified_name == b.qualified_name
+        && a.line_start == b.line_start
 }
 
 /// Default-on; opt-out via `CODESAGE_BUNDLE_LINE_NUMBERS=0` (or "false").

--- a/crates/graph/tests/impact_test.rs
+++ b/crates/graph/tests/impact_test.rs
@@ -503,6 +503,44 @@ fn export_context_callees_resolve_imported_helper_not_homonym() {
 }
 
 #[test]
+fn reverse_impact_attributes_caller_to_imported_helper_only() {
+    // Reverse counterpart of the forward test above: `service.rs` imports
+    // `helpers_a::helper`, so it must inflate `helpers_a`'s reverse blast radius
+    // but NOT `helpers_b`'s homonym. Before import-aware reverse resolution,
+    // `find_references` tail-matched "helper" and attributed the caller to both.
+    let (_dir, db) = setup_ambiguous_helper_rust_project();
+
+    let reverse_files = |path: &str| -> Vec<String> {
+        impact_analysis(
+            &db,
+            &ImpactRequest {
+                target: ImpactTarget::File {
+                    path: path.to_string(),
+                },
+                depth: 2,
+                source_only: false,
+            },
+        )
+        .unwrap()
+        .iter()
+        .map(|e| e.file_path.clone())
+        .collect()
+    };
+
+    let files_a = reverse_files("helpers_a.rs");
+    assert!(
+        files_a.iter().any(|p| p.ends_with("service.rs")),
+        "caller importing helpers_a must appear in its reverse impact: {files_a:?}"
+    );
+
+    let files_b = reverse_files("helpers_b.rs");
+    assert!(
+        !files_b.iter().any(|p| p.ends_with("service.rs")),
+        "caller importing helpers_a must NOT inflate helpers_b's reverse impact: {files_b:?}"
+    );
+}
+
+#[test]
 fn export_context_for_symbol_includes_callees() {
     let (_dir, db) = setup_callee_rust_project();
 


### PR DESCRIPTION
## What
Makes `impact_analysis` / `assess_risk` reverse-dependency resolution import-aware.

## Why
`references_for_symbol` matched reverse references by `to_name_tail`. An unqualified name (a method, a free function, a framework lifecycle hook) fanned out to every same-named definition. A reference to one class's `getAttributes()` got attributed to all of them, inflating the `dependent_files` blast-radius signal `assess_risk` weights. The forward resolver already disambiguates by the caller's imports; the reverse path didn't.

## How
Route each candidate reference back through `resolve_callee_definitions` and keep it only if it resolves to the target symbol. Unique names short-circuit, so distinctively-named symbols stay untouched; only ambiguous names get import-filtered. Cached per `(from_file, to_name)`.

## Impact (measured on real PHP/TS/Rust indexes)
Files whose blast was pure name-collision (framework lifecycle methods, shared utilities, trait-method impls) drop to their true dependent count. Genuinely central files keep their full import-resolved blast and risk score. The `assess_risk` composite shifts by at most the blast term's 0.09 weight; the practical effect is better separation between real and phantom hotspots.

## Test
`reverse_impact_attributes_caller_to_imported_helper_only`: a caller importing `helpers_a::helper` appears in `helpers_a`'s reverse impact but not `helpers_b`'s homonym. Fails without the fix.
