### PR TITLE
feat(similar): find_similar near-clone detection (MinHash over AST)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ PHP, Python, C, C++, Java, Rust, JavaScript, TypeScript, Go.
 - `search` -- semantic search with embedding + reranking
 - `find_symbol` -- symbol definitions by name
 - `find_references` -- references to a symbol; each row's `from_symbol` names the enclosing caller (null at file scope)
+- `find_similar` -- near-clone detection: functions/methods structurally similar to a named one (MinHash over AST shape, identifiers/literals ignored), ranked by Jaccard. Test files excluded. Needs fingerprints from a reindex.
 - `list_dependencies` -- file-level imports/imported-by
 - `impact_analysis` -- files affected by changing a symbol or file, with distance and reasons. Opt-in `include_forward` (forward deps), `include_siblings` (same-file symbols), `limit`, and `summary_only` controls; result is an object with `results` plus the requested extras.
 - `export_context` -- curated code bundle for a query or symbol, optionally with callers/callees
@@ -176,7 +177,7 @@ The daemon writes tracing to `mcp-<version>-<key>.log` in the runtime dir; check
 
 ## CLI commands
 
-`init`, `index`, `overview`, `search`, `find-symbol`, `find-references`, `dependencies`, `impact`, `export`, `status`, `mcp`, `daemon`, `watch`, `install-hooks`, `install`, `uninstall`, `cleanup`, `git-index`, `coupling`, `risk`, `risk-batch`, `risk-diff`, `tests-for`, `rehearse`, `session-start`, `session-end`, `doctor`, `map`, `features-list`, `feature-show`, `feature-for`, `feature-bundle`, `trust-boundaries`.
+`init`, `index`, `overview`, `search`, `find-symbol`, `find-references`, `dependencies`, `impact`, `export`, `status`, `mcp`, `daemon`, `watch`, `install-hooks`, `install`, `uninstall`, `cleanup`, `git-index`, `coupling`, `risk`, `risk-batch`, `risk-diff`, `similar`, `tests-for`, `rehearse`, `session-start`, `session-end`, `doctor`, `map`, `features-list`, `feature-show`, `feature-for`, `feature-bundle`, `trust-boundaries`.
 
 `watch run|status|stop|start [project]` controls the live filesystem watcher. The daemon auto-starts a per-project watcher on the first MCP tool call for that project (reusing the daemon's pooled embedder), debounces edits, and reindexes structural + semantic on change; it self-exits after idle (`CODESAGE_WATCH_IDLE_SECS`) and is reaped on daemon shutdown. Disable per project with `[index] watch = false` or globally with `CODESAGE_WATCH=0`. `watch run` is a foreground instance with its own embedder for debugging; `watch stop` writes a `.codesage/watch.disabled` marker the running watcher honors; `watch start` clears it. The watcher complements the git hooks, it does not replace them: it refreshes structural + semantic content live during a session, but git history intelligence (`git-index`, feeding `assess_risk` / `find_coupling`) and feature mapping still refresh only via the hooks or a full `codesage index`, and the watcher only runs while a daemon is alive.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- `find_similar` MCP tool and `codesage similar <name>` CLI command: near-clone detection for functions/methods via MinHash over AST structure (identifiers and literals ignored), ranked by Jaccard similarity. Test files are excluded; tune `--min-jaccard`. Requires a reindex (`codesage index`) to populate fingerprints (schema migration `0012_symbol_fingerprints`).
+
 ### Fixed
 - `impact_analysis` / `assess_risk` reverse-dependency resolution is now import-aware: a reference to an unqualified name is attributed only to the definition the caller imports, not to every same-named definition. Deflates inflated `dependent_files` blast radius for common names (framework lifecycle methods, shared utilities, trait-method implementations).
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -20,8 +20,8 @@ use codesage_embed::config::{EmbeddingConfig, ProjectConfig};
 use codesage_embed::model::Embedder;
 use codesage_graph::{
     assess_risk, export_context, export_context_for_symbol, find_coupling, find_references,
-    find_symbol, full_index, impact_analysis_report, incremental_index, list_dependencies, search,
-    semantic_full_index, semantic_incremental_index,
+    find_similar, find_symbol, full_index, impact_analysis_report, incremental_index,
+    list_dependencies, search, semantic_full_index, semantic_incremental_index,
 };
 use codesage_parser::discover::DEFAULT_EXCLUDE_PATTERNS;
 use codesage_protocol::{
@@ -265,6 +265,20 @@ enum Commands {
     Risk {
         /// Repo-relative file path (e.g. src/auth/login.php)
         file: String,
+        /// Emit JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Find functions structurally similar to a named one (near-clone detection)
+    Similar {
+        /// Function/method name to find clones of
+        symbol: String,
+        /// Minimum Jaccard similarity in [0, 1]
+        #[arg(long, default_value_t = 0.85)]
+        min_jaccard: f32,
+        /// Max results
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
         /// Emit JSON
         #[arg(long)]
         json: bool,
@@ -895,6 +909,12 @@ fn run(cli: Cli) -> Result<()> {
         } => cmd_git_index(json, full, incremental),
         Commands::Coupling { file, limit, json } => cmd_coupling(&file, limit, json),
         Commands::Risk { file, json } => cmd_risk(&file, json),
+        Commands::Similar {
+            symbol,
+            min_jaccard,
+            limit,
+            json,
+        } => cmd_similar(&symbol, min_jaccard, limit, json),
         Commands::RiskDiff { files, json } => cmd_risk_diff(files, json),
         Commands::RiskBatch { files, json } => cmd_risk_batch(files, json),
         Commands::TestsFor { files, json } => cmd_tests_for(files, json),
@@ -1742,6 +1762,26 @@ fn cmd_coupling(file: &str, limit: usize, json: bool) -> Result<()> {
         );
         for e in &report.coupled {
             println!("  {:>6.2}  {:>4}x  {}", e.weight, e.count, e.file);
+        }
+    }
+    Ok(())
+}
+
+fn cmd_similar(symbol: &str, min_jaccard: f32, limit: usize, json: bool) -> Result<()> {
+    let root = find_project_root()?;
+    let db = open_db(&root)?;
+    let hits = find_similar(&db, symbol, min_jaccard, limit)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&hits)?);
+    } else if hits.is_empty() {
+        println!("No clones of '{symbol}' at Jaccard >= {min_jaccard:.2}");
+    } else {
+        println!("Clones of '{symbol}' (Jaccard >= {min_jaccard:.2}):");
+        for h in &hits {
+            println!(
+                "  {:.3}  {}:{}-{}  {}()",
+                h.jaccard, h.file_path, h.line_start, h.line_end, h.name
+            );
         }
     }
     Ok(())

--- a/crates/cli/src/mcp.rs
+++ b/crates/cli/src/mcp.rs
@@ -10,15 +10,16 @@ use codesage_embed::model::Embedder;
 use codesage_embed::reranker::Reranker;
 use codesage_graph::{
     assess_risk, assess_risk_batch, assess_risk_diff, export_context, export_context_for_symbol,
-    feature_bundle, find_coupling, find_references, find_symbol, impact_analysis_report,
-    list_dependencies, recommend_tests, search, session_end, session_start,
+    feature_bundle, find_coupling, find_references, find_similar, find_symbol,
+    impact_analysis_report, list_dependencies, recommend_tests, search, session_end, session_start,
 };
 use codesage_protocol::{
     ContextBundle, CouplingReport, DependencyEntry, ExportRequest, FeatureKind, FeatureListResults,
-    FindReferencesRequest, FindReferencesResults, FindSymbolRequest, FindSymbolResults,
-    ImpactOptions, ImpactReport, ImpactRequest, ImpactTarget, Language, ProjectOverview,
-    ReferenceKind, ReviewRehearsal, RiskAssessment, RiskBatchAssessment, RiskDiffAssessment,
-    SearchRequest, SearchResults, SessionDiff, SessionSnapshot, SymbolKind, TestRecommendations,
+    FindReferencesRequest, FindReferencesResults, FindSimilarResults, FindSymbolRequest,
+    FindSymbolResults, ImpactOptions, ImpactReport, ImpactRequest, ImpactTarget, Language,
+    ProjectOverview, ReferenceKind, ReviewRehearsal, RiskAssessment, RiskBatchAssessment,
+    RiskDiffAssessment, SearchRequest, SearchResults, SessionDiff, SessionSnapshot, SymbolKind,
+    TestRecommendations,
 };
 use codesage_storage::Database;
 use parking_lot::Mutex;
@@ -91,6 +92,18 @@ pub struct FindReferencesParams {
         description = "Filter by reference kind: import, include, call, instantiation, inheritance, trait_use, type_hint"
     )]
     pub kind: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct FindSimilarParams {
+    #[schemars(description = PROJECT_ARG_DESC)]
+    pub project: String,
+    #[schemars(description = "Function/method name to find near-clones of")]
+    pub name: String,
+    #[schemars(description = "Minimum Jaccard similarity in [0, 1] (default 0.85)")]
+    pub min_jaccard: Option<f32>,
+    #[schemars(description = "Max results (default 20)")]
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -1383,6 +1396,29 @@ impl CodeSageServer {
                 &params.project,
                 s.with_project_db(&params.project, |db| find_references(db, &req)),
                 "find_references",
+            )
+        })
+        .await
+    }
+
+    #[tool(
+        name = "find_similar",
+        description = "Find functions/methods structurally similar to a named one (near-clone detection via MinHash over AST shape; identifiers and literals are ignored). Use before editing a function to find its copies so a fix lands everywhere, to spot divergent forks of a helper, or to locate copy-paste during review. Returns {name, file_path, line_start, line_end, kind, jaccard} ranked by similarity (1.0 = structurally identical body). Test files are excluded. Tune `min_jaccard` up for exact clones, down for looser matches.",
+        output_schema = schema_for_type::<FindSimilarResults>()
+    )]
+    async fn find_similar_tool(
+        &self,
+        Parameters(params): Parameters<FindSimilarParams>,
+    ) -> CallToolResult {
+        self.blocking(move |s| {
+            let min_jaccard = params.min_jaccard.unwrap_or(0.85);
+            let limit = params.limit.unwrap_or(20);
+            s.render(
+                &params.project,
+                s.with_project_db(&params.project, |db| {
+                    find_similar(db, &params.name, min_jaccard, limit)
+                }),
+                "find_similar",
             )
         })
         .await

--- a/crates/cli/src/mcp.rs
+++ b/crates/cli/src/mcp.rs
@@ -103,6 +103,7 @@ pub struct FindSimilarParams {
     #[schemars(description = "Minimum Jaccard similarity in [0, 1] (default 0.85)")]
     pub min_jaccard: Option<f32>,
     #[schemars(description = "Max results (default 20)")]
+    #[serde(default, deserialize_with = "deser_optional_usize")]
     pub limit: Option<usize>,
 }
 

--- a/crates/graph/src/index.rs
+++ b/crates/graph/src/index.rs
@@ -4,10 +4,12 @@ use anyhow::{Context, Result};
 use codesage_features::trust_boundary::derive_from_refs;
 use codesage_protocol::{FileInfo, IndexStats, Reference, Symbol};
 use codesage_storage::Database;
+use codesage_storage::db::FingerprintInput;
 use rayon::prelude::*;
 
 use codesage_parser::discover::discover_files_with_excludes;
 use codesage_parser::extract::extract_symbols;
+use codesage_parser::fingerprint::{FunctionFingerprint, file_fingerprints};
 use codesage_parser::parse::parse_file;
 use codesage_parser::references::extract_references;
 
@@ -16,6 +18,7 @@ struct ParsedFile {
     info: FileInfo,
     symbols: Vec<Symbol>,
     refs: Vec<Reference>,
+    fingerprints: Vec<FunctionFingerprint>,
 }
 
 fn parse_one(root: &Path, file_info: &FileInfo) -> Result<ParsedFile> {
@@ -28,11 +31,28 @@ fn parse_one(root: &Path, file_info: &FileInfo) -> Result<ParsedFile> {
     let mut refs = extract_references(&tree, &source, file_info.language, &file_info.path)
         .with_context(|| format!("extracting references from {}", file_info.path))?;
     populate_from_symbol(&symbols, &mut refs);
+    let fingerprints = file_fingerprints(&tree, &source, file_info.language);
     Ok(ParsedFile {
         info: file_info.clone(),
         symbols,
         refs,
+        fingerprints,
     })
+}
+
+/// Map parsed fingerprints to borrowed insert rows.
+fn fingerprint_inputs(p: &ParsedFile) -> Vec<FingerprintInput<'_>> {
+    p.fingerprints
+        .iter()
+        .map(|f| FingerprintInput {
+            name: &f.name,
+            kind: f.kind.as_str(),
+            line_start: f.line_start,
+            line_end: f.line_end,
+            leaf_count: f.leaf_count as u32,
+            fp: &f.fp,
+        })
+        .collect()
 }
 
 /// Set each reference's `from_symbol` to the qualified name of the innermost
@@ -148,6 +168,7 @@ fn index(
             let file_id = db.upsert_file(&p.info)?;
             db.insert_symbols(file_id, &p.symbols)?;
             db.insert_references(file_id, &p.refs)?;
+            db.insert_fingerprints(file_id, &fingerprint_inputs(p))?;
             // Trust-boundary derivation runs against the in-memory refs we
             // just inserted — no DB round-trip to re-read them. Replace
             // whatever was stored previously so re-index keeps the set
@@ -224,6 +245,7 @@ pub fn index_files(
             let file_id = db.upsert_file(&p.info)?;
             db.insert_symbols(file_id, &p.symbols)?;
             db.insert_references(file_id, &p.refs)?;
+            db.insert_fingerprints(file_id, &fingerprint_inputs(p))?;
             let boundaries = derive_from_refs(&p.refs, p.info.language);
             db.replace_file_trust_boundaries(file_id, &boundaries)?;
         }

--- a/crates/graph/src/lib.rs
+++ b/crates/graph/src/lib.rs
@@ -4,6 +4,7 @@ pub mod query;
 mod scc;
 pub mod semantic;
 pub mod session;
+pub mod similar;
 
 pub use git_history::{
     IndexMode, assess_risk, assess_risk_batch, assess_risk_diff, changed_files_since,
@@ -19,3 +20,4 @@ pub use semantic::{
     semantic_full_index, semantic_incremental_index, semantic_index_files, semantic_remove_files,
 };
 pub use session::{session_end, session_start, top_risk_files};
+pub use similar::find_similar;

--- a/crates/graph/src/similar.rs
+++ b/crates/graph/src/similar.rs
@@ -1,0 +1,104 @@
+//! Near-clone detection over stored MinHash fingerprints.
+//!
+//! `find_similar` loads every function fingerprint, builds an LSH band index
+//! (so we score O(candidates) instead of O(n²) all-pairs), and returns the
+//! functions structurally closest to a named target, ranked by Jaccard.
+//! Identifiers and literals are ignored — this matches code *shape*, which is
+//! what surfaces copy-paste and divergent forks.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Result;
+use codesage_parser::fingerprint::{Fingerprint, band_keys, jaccard};
+use codesage_protocol::{FileCategory, SimilarSymbol};
+use codesage_storage::Database;
+
+fn as_sig(fp: &[u64]) -> Option<&Fingerprint> {
+    fp.try_into().ok()
+}
+
+/// Functions structurally similar to `symbol_name`, Jaccard ≥ `min_jaccard`,
+/// capped at `limit`. Test files are excluded from the candidate set (clone
+/// scaffolding there is noise, not actionable). The target's own occurrence is
+/// never returned as its own clone.
+pub fn find_similar(
+    db: &Database,
+    symbol_name: &str,
+    min_jaccard: f32,
+    limit: usize,
+) -> Result<Vec<SimilarSymbol>> {
+    let all = db.all_fingerprints()?;
+    let targets: Vec<usize> = all
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| f.name == symbol_name)
+        .map(|(i, _)| i)
+        .collect();
+    if targets.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // LSH band index over non-test fingerprints: band key → candidate indices.
+    let mut buckets: HashMap<u64, Vec<usize>> = HashMap::new();
+    for (i, f) in all.iter().enumerate() {
+        if matches!(FileCategory::classify(&f.file_path), FileCategory::Test) {
+            continue;
+        }
+        if let Some(sig) = as_sig(&f.fp) {
+            for key in band_keys(sig) {
+                buckets.entry(key).or_default().push(i);
+            }
+        }
+    }
+
+    // Best score per distinct (file, line) clone location.
+    let mut best: HashMap<(String, u32), SimilarSymbol> = HashMap::new();
+    for &ti in &targets {
+        let target = &all[ti];
+        let Some(tsig) = as_sig(&target.fp) else {
+            continue;
+        };
+        let mut candidates = HashSet::new();
+        for key in band_keys(tsig) {
+            if let Some(ids) = buckets.get(&key) {
+                candidates.extend(ids.iter().copied());
+            }
+        }
+        for ci in candidates {
+            let c = &all[ci];
+            // Skip the target's own occurrence(s).
+            if c.file_path == target.file_path && c.line_start == target.line_start {
+                continue;
+            }
+            let Some(csig) = as_sig(&c.fp) else {
+                continue;
+            };
+            let score = jaccard(tsig, csig);
+            if score < min_jaccard {
+                continue;
+            }
+            let entry = best
+                .entry((c.file_path.clone(), c.line_start))
+                .or_insert_with(|| SimilarSymbol {
+                    name: c.name.clone(),
+                    file_path: c.file_path.clone(),
+                    line_start: c.line_start,
+                    line_end: c.line_end,
+                    kind: c.kind.clone(),
+                    jaccard: 0.0,
+                });
+            if score > entry.jaccard {
+                entry.jaccard = score;
+            }
+        }
+    }
+
+    let mut out: Vec<SimilarSymbol> = best.into_values().collect();
+    out.sort_by(|a, b| {
+        b.jaccard
+            .partial_cmp(&a.jaccard)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    out.truncate(limit);
+    Ok(out)
+}

--- a/crates/graph/src/similar.rs
+++ b/crates/graph/src/similar.rs
@@ -27,6 +27,15 @@ pub fn find_similar(
     min_jaccard: f32,
     limit: usize,
 ) -> Result<Vec<SimilarSymbol>> {
+    // Guard against NaN / out-of-range thresholds: NaN would bypass the `<`
+    // filter (admitting everything) and a negative bound admits every LSH
+    // candidate.
+    let min_jaccard = if min_jaccard.is_finite() {
+        min_jaccard.clamp(0.0, 1.0)
+    } else {
+        0.85
+    };
+
     let all = db.all_fingerprints()?;
     let targets: Vec<usize> = all
         .iter()
@@ -38,15 +47,21 @@ pub fn find_similar(
         return Ok(Vec::new());
     }
 
-    // LSH band index over non-test fingerprints: band key → candidate indices.
-    let mut buckets: HashMap<u64, Vec<usize>> = HashMap::new();
+    // LSH band index over non-test fingerprints, keyed by (language, band key).
+    // Tree-sitter `kind_id`s are grammar-local, so fingerprints only compare
+    // within a language — bucketing on language prevents cross-language
+    // coincidental matches with meaningless Jaccard scores.
+    let mut buckets: HashMap<(&str, u64), Vec<usize>> = HashMap::new();
     for (i, f) in all.iter().enumerate() {
         if matches!(FileCategory::classify(&f.file_path), FileCategory::Test) {
             continue;
         }
         if let Some(sig) = as_sig(&f.fp) {
             for key in band_keys(sig) {
-                buckets.entry(key).or_default().push(i);
+                buckets
+                    .entry((f.language.as_str(), key))
+                    .or_default()
+                    .push(i);
             }
         }
     }
@@ -60,7 +75,7 @@ pub fn find_similar(
         };
         let mut candidates = HashSet::new();
         for key in band_keys(tsig) {
-            if let Some(ids) = buckets.get(&key) {
+            if let Some(ids) = buckets.get(&(target.language.as_str(), key)) {
                 candidates.extend(ids.iter().copied());
             }
         }

--- a/crates/graph/tests/similar_test.rs
+++ b/crates/graph/tests/similar_test.rs
@@ -1,0 +1,58 @@
+use codesage_graph::{find_similar, full_index};
+use codesage_storage::Database;
+
+/// Two structurally identical functions (differing only in identifiers and
+/// literals) plus one unrelated function. `find_similar` on one clone should
+/// surface the other and not the unrelated function.
+fn setup() -> (tempfile::TempDir, Database) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    std::fs::write(
+        root.join("a.rs"),
+        b"pub fn alpha(items: &[i32]) -> i32 {\n    let mut total = 0;\n    for it in items {\n        if *it > 0 {\n            total += *it * 2;\n        } else {\n            total -= 1;\n        }\n    }\n    total\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("b.rs"),
+        b"pub fn beta(values: &[i32]) -> i32 {\n    let mut acc = 0;\n    for v in values {\n        if *v > 0 {\n            acc += *v * 2;\n        } else {\n            acc -= 1;\n        }\n    }\n    acc\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("c.rs"),
+        b"pub fn gamma(name: &str) -> String {\n    let mut out = String::new();\n    out.push_str(\"hello \");\n    out.push_str(name);\n    out.push('!');\n    out.push_str(\" and welcome\");\n    out\n}\n",
+    )
+    .unwrap();
+
+    let db = Database::open_in_memory().unwrap();
+    full_index(root, &db, &[], false).unwrap();
+    (dir, db)
+}
+
+#[test]
+fn find_similar_surfaces_clone_not_unrelated() {
+    let (_dir, db) = setup();
+
+    let hits = find_similar(&db, "alpha", 0.8, 10).unwrap();
+    assert!(
+        hits.iter()
+            .any(|h| h.name == "beta" && h.file_path == "b.rs"),
+        "expected beta as a clone of alpha, got {hits:?}"
+    );
+    assert!(
+        !hits.iter().any(|h| h.name == "gamma"),
+        "unrelated gamma must not be reported as a clone: {hits:?}"
+    );
+    let beta = hits.iter().find(|h| h.name == "beta").unwrap();
+    assert!(
+        beta.jaccard >= 0.8,
+        "clone jaccard too low: {}",
+        beta.jaccard
+    );
+}
+
+#[test]
+fn find_similar_unknown_symbol_is_empty() {
+    let (_dir, db) = setup();
+    assert!(find_similar(&db, "no_such_fn", 0.8, 10).unwrap().is_empty());
+}

--- a/crates/parser/src/extract.rs
+++ b/crates/parser/src/extract.rs
@@ -19,10 +19,10 @@ static GO_QUERY: &str = include_str!("queries/go.scm");
 /// per language on first use, then reused across every file. `capture_index_for_name`
 /// is O(n) over captures, so caching it beside the Query matters when the indexer
 /// runs through tens of thousands of files.
-struct SymbolQuerySpec {
-    query: Query,
-    name_idx: u32,
-    def_idx: u32,
+pub(crate) struct SymbolQuerySpec {
+    pub(crate) query: Query,
+    pub(crate) name_idx: u32,
+    pub(crate) def_idx: u32,
 }
 
 fn compile_symbol_query(lang: tree_sitter::Language, src: &str) -> SymbolQuerySpec {
@@ -62,7 +62,7 @@ static TS_SYM: LazyLock<SymbolQuerySpec> = LazyLock::new(|| {
 static GO_SYM: LazyLock<SymbolQuerySpec> =
     LazyLock::new(|| compile_symbol_query(crate::parse::ts_language(Language::Go), GO_QUERY));
 
-fn symbol_query_for(lang: Language) -> &'static SymbolQuerySpec {
+pub(crate) fn symbol_query_for(lang: Language) -> &'static SymbolQuerySpec {
     match lang {
         Language::Php => &PHP_SYM,
         Language::Python => &PY_SYM,
@@ -73,6 +73,23 @@ fn symbol_query_for(lang: Language) -> &'static SymbolQuerySpec {
         Language::JavaScript => &JS_SYM,
         Language::TypeScript => &TS_SYM,
         Language::Go => &GO_SYM,
+    }
+}
+
+/// The pattern-index → `SymbolKind` map for a language, shared by
+/// `extract_symbols` and the fingerprint pass so both agree on which `@def`
+/// matches are functions/methods.
+pub(crate) fn kind_map_for(language: Language) -> fn(usize) -> Option<SymbolKind> {
+    match language {
+        Language::Php => php_kind_map,
+        Language::Python => python_kind_map,
+        Language::C => c_kind_map,
+        Language::Cpp => cpp_kind_map,
+        Language::Java => java_kind_map,
+        Language::Rust => rust_kind_map,
+        Language::JavaScript => js_kind_map,
+        Language::TypeScript => ts_kind_map,
+        Language::Go => go_kind_map,
     }
 }
 
@@ -220,17 +237,7 @@ pub fn extract_symbols(
     language: Language,
     file_path: &str,
 ) -> Result<Vec<Symbol>> {
-    let kind_map: fn(usize) -> Option<SymbolKind> = match language {
-        Language::Php => php_kind_map,
-        Language::Python => python_kind_map,
-        Language::C => c_kind_map,
-        Language::Cpp => cpp_kind_map,
-        Language::Java => java_kind_map,
-        Language::Rust => rust_kind_map,
-        Language::JavaScript => js_kind_map,
-        Language::TypeScript => ts_kind_map,
-        Language::Go => go_kind_map,
-    };
+    let kind_map = kind_map_for(language);
 
     let spec = symbol_query_for(language);
     let query = &spec.query;

--- a/crates/parser/src/extract.rs
+++ b/crates/parser/src/extract.rs
@@ -456,7 +456,7 @@ fn is_inside_impl_or_class(node: &Node, language: Language) -> bool {
 /// in-class definitions. Destructors (`~Foo`) and operators (`operator+`) are
 /// returned as-is because the leading marker is part of the conventional
 /// search term.
-fn cpp_bare_name(captured: &str) -> String {
+pub(crate) fn cpp_bare_name(captured: &str) -> String {
     captured.rsplit("::").next().unwrap_or(captured).to_string()
 }
 

--- a/crates/parser/src/fingerprint.rs
+++ b/crates/parser/src/fingerprint.rs
@@ -143,8 +143,18 @@ pub fn file_fingerprints(
         let Some((fp, leaves)) = fingerprint_def(&def) else {
             continue;
         };
+        // Normalize the captured name the same way `extract_symbols` does, so a
+        // fingerprint's name matches what `find_symbol` stores (C++ out-of-line
+        // `Foo::bar` captures as bare `bar`). Otherwise `find_similar bar` would
+        // miss C++ methods.
+        let captured = name_cap.node.utf8_text(source).unwrap_or("");
+        let name = if language == Language::Cpp {
+            crate::extract::cpp_bare_name(captured)
+        } else {
+            captured.to_string()
+        };
         out.push(FunctionFingerprint {
-            name: name_cap.node.utf8_text(source).unwrap_or("").to_string(),
+            name,
             kind,
             line_start: def.start_position().row as u32 + 1,
             line_end: def.end_position().row as u32 + 1,

--- a/crates/parser/src/fingerprint.rs
+++ b/crates/parser/src/fingerprint.rs
@@ -1,0 +1,274 @@
+//! Spike (CBM port): MinHash fingerprints over AST node-kind trigrams for
+//! near-clone detection. Mirrors codebase-memory-mcp's `simhash/minhash.h`:
+//! K=64 permutations, a leaf-token floor, and LSH banding for O(n) candidate
+//! generation instead of O(n²) all-pairs.
+//!
+//! Fingerprints are only comparable *within a language* — tree-sitter
+//! `kind_id`s are grammar-local integers, so a `block` in C and a `block` in
+//! PHP need not share an id. Cross-language clone detection is out of scope
+//! for this spike (and rarely what an agent wants anyway).
+
+use std::collections::HashSet;
+
+use codesage_protocol::{Language, SymbolKind};
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Node, QueryCursor, Tree};
+
+/// MinHash permutations. 64 gives ~±0.12 std error on the Jaccard estimate,
+/// matching CBM's K and sufficient to separate clones at a 0.8 threshold.
+pub const MINHASH_K: usize = 64;
+
+/// Minimum leaf (token) nodes a function needs before we fingerprint it.
+/// Below this the trigram set is too small for a stable estimate and every
+/// one-line getter collides with every other. ~30 leaves ≈ BigCloneBench's
+/// 50-raw-token floor.
+pub const MIN_LEAF_NODES: usize = 30;
+
+/// LSH banding: `MINHASH_K = LSH_BANDS * LSH_ROWS`. Two fingerprints become
+/// candidates when they agree on every row of at least one band. 16×4 has a
+/// ~50% trip probability around Jaccard 0.7, climbing sharply above that.
+pub const LSH_BANDS: usize = 16;
+pub const LSH_ROWS: usize = MINHASH_K / LSH_BANDS;
+
+pub type Fingerprint = [u64; MINHASH_K];
+
+/// One fingerprinted function/method.
+#[derive(Debug, Clone)]
+pub struct FunctionFingerprint {
+    pub name: String,
+    pub kind: SymbolKind,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub leaf_count: usize,
+    pub fp: Fingerprint,
+}
+
+#[inline]
+const fn splitmix64(x: u64) -> u64 {
+    let x = x.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    let mut z = x;
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+const SEEDS: [u64; MINHASH_K] = {
+    let mut s = [0u64; MINHASH_K];
+    let mut i = 0;
+    while i < MINHASH_K {
+        s[i] = splitmix64(i as u64 + 1);
+        i += 1;
+    }
+    s
+};
+
+/// Pre-order walk of `node`, pushing each node's `kind_id` and counting leaves
+/// (childless nodes — the actual source tokens). Order is preserved so the
+/// trigram sequence reflects structure, not just a node-kind bag.
+fn collect_preorder(node: &Node, kinds: &mut Vec<u16>, leaves: &mut usize) {
+    kinds.push(node.kind_id());
+    let mut cursor = node.walk();
+    let mut had_child = false;
+    for child in node.children(&mut cursor) {
+        had_child = true;
+        collect_preorder(&child, kinds, leaves);
+    }
+    if !had_child {
+        *leaves += 1;
+    }
+}
+
+/// MinHash of a pre-order node-kind sequence, hashing consecutive trigrams.
+fn minhash(kinds: &[u16]) -> Fingerprint {
+    let mut mins = [u64::MAX; MINHASH_K];
+    for w in kinds.windows(3) {
+        let v = ((w[0] as u64) << 32) | ((w[1] as u64) << 16) | (w[2] as u64);
+        for i in 0..MINHASH_K {
+            let h = splitmix64(v ^ SEEDS[i]);
+            if h < mins[i] {
+                mins[i] = h;
+            }
+        }
+    }
+    mins
+}
+
+/// Fingerprint a single definition subtree. `None` when the body is too small
+/// to fingerprint reliably (see [`MIN_LEAF_NODES`]).
+pub fn fingerprint_def(def: &Node) -> Option<(Fingerprint, usize)> {
+    let mut kinds = Vec::new();
+    let mut leaves = 0usize;
+    collect_preorder(def, &mut kinds, &mut leaves);
+    if leaves < MIN_LEAF_NODES || kinds.len() < 3 {
+        return None;
+    }
+    Some((minhash(&kinds), leaves))
+}
+
+/// Fingerprint every function/method definition in a parsed file. Reuses the
+/// same compiled symbol query and pattern→kind map as `extract_symbols`, so
+/// the set of fingerprinted defs matches the set of indexed function symbols.
+pub fn file_fingerprints(
+    tree: &Tree,
+    source: &[u8],
+    language: Language,
+) -> Vec<FunctionFingerprint> {
+    let spec = crate::extract::symbol_query_for(language);
+    let kind_map = crate::extract::kind_map_for(language);
+
+    let root = tree.root_node();
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(&spec.query, root, source);
+
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+
+    while let Some(m) = matches.next() {
+        let Some(kind) = kind_map(m.pattern_index) else {
+            continue;
+        };
+        if !matches!(kind, SymbolKind::Function | SymbolKind::Method) {
+            continue;
+        }
+        let (Some(def_cap), Some(name_cap)) = (
+            m.captures.iter().find(|c| c.index == spec.def_idx),
+            m.captures.iter().find(|c| c.index == spec.name_idx),
+        ) else {
+            continue;
+        };
+        let def = def_cap.node;
+        if !seen.insert((def.start_byte(), def.end_byte())) {
+            continue;
+        }
+        let Some((fp, leaves)) = fingerprint_def(&def) else {
+            continue;
+        };
+        out.push(FunctionFingerprint {
+            name: name_cap.node.utf8_text(source).unwrap_or("").to_string(),
+            kind,
+            line_start: def.start_position().row as u32 + 1,
+            line_end: def.end_position().row as u32 + 1,
+            leaf_count: leaves,
+            fp,
+        });
+    }
+    out
+}
+
+/// Estimated Jaccard similarity: fraction of MinHash positions that agree.
+#[inline]
+pub fn jaccard(a: &Fingerprint, b: &Fingerprint) -> f32 {
+    let eq = a.iter().zip(b.iter()).filter(|(x, y)| x == y).count();
+    eq as f32 / MINHASH_K as f32
+}
+
+/// LSH band signatures for candidate bucketing. Two functions that share any
+/// band key are worth scoring exactly; the rest are never compared.
+pub fn band_keys(fp: &Fingerprint) -> [u64; LSH_BANDS] {
+    let mut keys = [0u64; LSH_BANDS];
+    for (b, key) in keys.iter_mut().enumerate() {
+        // FNV-1a over the band's rows.
+        let mut h = 0xcbf2_9ce4_8422_2325u64;
+        for r in 0..LSH_ROWS {
+            h ^= fp[b * LSH_ROWS + r];
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        // Mix the band index in so identical row-runs in different bands don't
+        // collide into one bucket.
+        *key = h ^ splitmix64(b as u64);
+    }
+    keys
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::parse_file;
+
+    fn fps(src: &str, lang: Language) -> Vec<FunctionFingerprint> {
+        let tree = parse_file(src.as_bytes(), lang).unwrap();
+        file_fingerprints(&tree, src.as_bytes(), lang)
+    }
+
+    #[test]
+    fn near_clone_scores_high_unrelated_scores_low() {
+        // Two structurally identical functions differing only in identifiers
+        // and literals; one structurally unrelated function.
+        let src = r#"
+fn alpha(items: &[i32]) -> i32 {
+    let mut total = 0;
+    for it in items {
+        if *it > 0 {
+            total += *it * 2;
+        } else {
+            total -= 1;
+        }
+    }
+    total
+}
+
+fn beta(values: &[i32]) -> i32 {
+    let mut acc = 0;
+    for v in values {
+        if *v > 0 {
+            acc += *v * 2;
+        } else {
+            acc -= 1;
+        }
+    }
+    acc
+}
+
+fn gamma(name: &str) -> String {
+    let mut out = String::new();
+    out.push_str("hello ");
+    out.push_str(name);
+    out.push('!');
+    out
+}
+"#;
+        let f = fps(src, Language::Rust);
+        assert_eq!(f.len(), 3, "expected 3 functions, got {}", f.len());
+        let alpha = f.iter().find(|x| x.name == "alpha").unwrap();
+        let beta = f.iter().find(|x| x.name == "beta").unwrap();
+        let gamma = f.iter().find(|x| x.name == "gamma").unwrap();
+
+        let clone = jaccard(&alpha.fp, &beta.fp);
+        let unrelated = jaccard(&alpha.fp, &gamma.fp);
+        assert!(
+            clone > 0.85,
+            "near-clone Jaccard should be high, got {clone}"
+        );
+        assert!(
+            clone > unrelated + 0.3,
+            "clone ({clone}) should clearly beat unrelated ({unrelated})"
+        );
+
+        // LSH must bucket the clones together and (very likely) not the
+        // unrelated one.
+        let ka = band_keys(&alpha.fp);
+        let kb = band_keys(&beta.fp);
+        assert!(
+            ka.iter().any(|k| kb.contains(k)),
+            "clones should share at least one LSH band"
+        );
+    }
+
+    #[test]
+    fn identical_bodies_are_jaccard_one() {
+        let src = r#"
+fn one(x: i32) -> i32 { let mut s = 0; for i in 0..x { s += i; if s > 100 { break; } } s }
+fn two(x: i32) -> i32 { let mut s = 0; for i in 0..x { s += i; if s > 100 { break; } } s }
+"#;
+        let f = fps(src, Language::Rust);
+        assert_eq!(f.len(), 2);
+        assert!((jaccard(&f[0].fp, &f[1].fp) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn tiny_functions_are_skipped() {
+        // A trivial getter is below the leaf floor and should not fingerprint.
+        let src = "fn id(x: i32) -> i32 { x }\n";
+        assert!(fps(src, Language::Rust).is_empty());
+    }
+}

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod detect;
 pub mod discover;
 pub mod extract;
+pub mod fingerprint;
 pub mod parse;
 pub mod position;
 pub mod rationale;

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -289,6 +289,20 @@ pub struct FindSymbolRequest {
     pub kind: Option<SymbolKind>,
 }
 
+/// One near-clone of a queried function, scored by MinHash Jaccard similarity
+/// over AST structure. Returned by `find_similar`.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SimilarSymbol {
+    pub name: String,
+    pub file_path: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub kind: String,
+    /// Estimated Jaccard similarity in [0, 1]; 1.0 is a structurally identical
+    /// body (identifiers and literals are ignored).
+    pub jaccard: f32,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct FindReferencesRequest {
     pub symbol_name: String,
@@ -1148,6 +1162,12 @@ pub struct FindReferencesResults {
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SearchResults {
     pub results: Vec<SearchResult>,
+}
+
+/// `{"results": [...]}` envelope around `Vec<SimilarSymbol>`. See [`FindSymbolResults`].
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct FindSimilarResults {
+    pub results: Vec<SimilarSymbol>,
 }
 
 /// `{"results": [...]}` envelope around `Vec<ImpactEntry>`. See [`FindSymbolResults`].

--- a/crates/storage/src/db/mod.rs
+++ b/crates/storage/src/db/mod.rs
@@ -32,6 +32,7 @@ mod structural;
 
 pub use git_hist::{CoChangeRow, GitFileRow};
 pub use semantic::{RawSearchRow, SemanticFreshness, embedding_to_bytes};
+pub use structural::{FingerprintInput, StoredFingerprint};
 
 /// Decode a stored DB string column into an enum via its `parse`, surfacing an
 /// unknown value as a typed rusqlite error rather than silently relabeling it.

--- a/crates/storage/src/db/structural.rs
+++ b/crates/storage/src/db/structural.rs
@@ -60,10 +60,11 @@ pub struct FingerprintInput<'a> {
     pub fp: &'a [u64],
 }
 
-/// Owned fingerprint row as read back, with its file path.
+/// Owned fingerprint row as read back, with its file path and language.
 #[derive(Debug, Clone)]
 pub struct StoredFingerprint {
     pub file_path: String,
+    pub language: String,
     pub name: String,
     pub kind: String,
     pub line_start: u32,
@@ -81,6 +82,12 @@ fn fp_to_blob(fp: &[u64]) -> Vec<u8> {
 }
 
 fn blob_to_fp(b: &[u8]) -> Vec<u64> {
+    // A non-8-multiple blob is corrupt; return empty so the caller's
+    // fixed-length conversion rejects it rather than silently dropping the
+    // trailing bytes and decoding a plausible-but-wrong signature.
+    if !b.len().is_multiple_of(8) {
+        return Vec::new();
+    }
     b.chunks_exact(8)
         .map(|c| u64::from_le_bytes(c.try_into().expect("chunks_exact(8) yields 8 bytes")))
         .collect()
@@ -215,18 +222,19 @@ impl Database {
     /// function count; fine for repos up to the low hundreds of thousands.
     pub fn all_fingerprints(&self) -> Result<Vec<StoredFingerprint>> {
         let mut stmt = self.conn.prepare(
-            "SELECT f.path, sf.name, sf.kind, sf.line_start, sf.line_end, sf.leaf_count, sf.fp
+            "SELECT f.path, f.language, sf.name, sf.kind, sf.line_start, sf.line_end, sf.leaf_count, sf.fp
              FROM symbol_fingerprints sf JOIN files f ON sf.file_id = f.id",
         )?;
         let rows = stmt.query_map([], |row| {
-            let blob: Vec<u8> = row.get(6)?;
+            let blob: Vec<u8> = row.get(7)?;
             Ok(StoredFingerprint {
                 file_path: row.get(0)?,
-                name: row.get(1)?,
-                kind: row.get(2)?,
-                line_start: row.get(3)?,
-                line_end: row.get(4)?,
-                leaf_count: row.get(5)?,
+                language: row.get(1)?,
+                name: row.get(2)?,
+                kind: row.get(3)?,
+                line_start: row.get(4)?,
+                line_end: row.get(5)?,
+                leaf_count: row.get(6)?,
                 fp: blob_to_fp(&blob),
             })
         })?;

--- a/crates/storage/src/db/structural.rs
+++ b/crates/storage/src/db/structural.rs
@@ -50,6 +50,42 @@ fn row_to_file_lang(row: &rusqlite::Row<'_>) -> rusqlite::Result<(i64, String, L
     Ok((id, path, row_enum(&lang_str, Language::parse, "Language")?))
 }
 
+/// Borrowed fingerprint row for insertion. `fp` is the MinHash signature.
+pub struct FingerprintInput<'a> {
+    pub name: &'a str,
+    pub kind: &'a str,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub leaf_count: u32,
+    pub fp: &'a [u64],
+}
+
+/// Owned fingerprint row as read back, with its file path.
+#[derive(Debug, Clone)]
+pub struct StoredFingerprint {
+    pub file_path: String,
+    pub name: String,
+    pub kind: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub leaf_count: u32,
+    pub fp: Vec<u64>,
+}
+
+fn fp_to_blob(fp: &[u64]) -> Vec<u8> {
+    let mut b = Vec::with_capacity(fp.len() * 8);
+    for &x in fp {
+        b.extend_from_slice(&x.to_le_bytes());
+    }
+    b
+}
+
+fn blob_to_fp(b: &[u8]) -> Vec<u64> {
+    b.chunks_exact(8)
+        .map(|c| u64::from_le_bytes(c.try_into().expect("chunks_exact(8) yields 8 bytes")))
+        .collect()
+}
+
 impl Database {
     /// Return `(last_sha, last_indexed_at_unix)` for the structural index if a
     /// stamp exists. Mirrors [`Database::get_git_index_state`] but tracks the
@@ -88,6 +124,10 @@ impl Database {
             .execute("DELETE FROM symbols WHERE file_id = ?1", params![file_id])?;
         self.conn
             .execute("DELETE FROM refs WHERE from_file_id = ?1", params![file_id])?;
+        self.conn.execute(
+            "DELETE FROM symbol_fingerprints WHERE file_id = ?1",
+            params![file_id],
+        )?;
         self.conn.execute(
             "DELETE FROM file_trust_boundaries WHERE file_id = ?1",
             params![file_id],
@@ -146,6 +186,51 @@ impl Database {
             ])?;
         }
         Ok(())
+    }
+
+    /// Persist MinHash fingerprints for one file's functions/methods. Caller
+    /// deletes prior rows via `upsert_file`; this only inserts.
+    pub fn insert_fingerprints(&self, file_id: i64, fps: &[FingerprintInput<'_>]) -> Result<()> {
+        let mut stmt = self.conn.prepare(
+            "INSERT INTO symbol_fingerprints
+                 (file_id, name, kind, line_start, line_end, leaf_count, fp)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        )?;
+        for f in fps {
+            stmt.execute(params![
+                file_id,
+                f.name,
+                f.kind,
+                f.line_start,
+                f.line_end,
+                f.leaf_count,
+                fp_to_blob(f.fp),
+            ])?;
+        }
+        Ok(())
+    }
+
+    /// Every stored function fingerprint with its file path. Loaded whole by
+    /// `find_similar`, which builds the LSH index in memory. Scales with the
+    /// function count; fine for repos up to the low hundreds of thousands.
+    pub fn all_fingerprints(&self) -> Result<Vec<StoredFingerprint>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT f.path, sf.name, sf.kind, sf.line_start, sf.line_end, sf.leaf_count, sf.fp
+             FROM symbol_fingerprints sf JOIN files f ON sf.file_id = f.id",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            let blob: Vec<u8> = row.get(6)?;
+            Ok(StoredFingerprint {
+                file_path: row.get(0)?,
+                name: row.get(1)?,
+                kind: row.get(2)?,
+                line_start: row.get(3)?,
+                line_end: row.get(4)?,
+                leaf_count: row.get(5)?,
+                fp: blob_to_fp(&blob),
+            })
+        })?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
     /// Resolve a repo-relative path to its `files.id`, or `None` if the

--- a/crates/storage/src/schema.rs
+++ b/crates/storage/src/schema.rs
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS symbol_fingerprints (
     line_start INTEGER NOT NULL,
     line_end INTEGER NOT NULL,
     leaf_count INTEGER NOT NULL,
-    fp BLOB NOT NULL
+    fp BLOB NOT NULL CHECK (length(fp) = 512)
 );
 
 CREATE INDEX IF NOT EXISTS idx_symfp_file ON symbol_fingerprints(file_id);
@@ -452,25 +452,6 @@ fn migrate_0010_files_boundaries_derived_at(conn: &Connection) -> rusqlite::Resu
 /// change as the project's package-manager / lockfile evolves, so they
 /// must not destabilize feature identity. Existing rows default to NULL
 /// and get populated on the next `codesage index` mapper pass.
-/// Adds the `symbol_fingerprints` table (per-function MinHash for near-clone
-/// detection). Idempotent via `IF NOT EXISTS`; existing indexes get the table
-/// empty and populate it on the next `codesage index`.
-fn migrate_0012_symbol_fingerprints(conn: &Connection) -> rusqlite::Result<()> {
-    conn.execute_batch(
-        "CREATE TABLE IF NOT EXISTS symbol_fingerprints (
-             file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
-             name TEXT NOT NULL,
-             kind TEXT NOT NULL,
-             line_start INTEGER NOT NULL,
-             line_end INTEGER NOT NULL,
-             leaf_count INTEGER NOT NULL,
-             fp BLOB NOT NULL
-         );
-         CREATE INDEX IF NOT EXISTS idx_symfp_file ON symbol_fingerprints(file_id);",
-    )?;
-    Ok(())
-}
-
 fn migrate_0011_features_test_command(conn: &Connection) -> rusqlite::Result<()> {
     let has_column: i64 = conn.query_row(
         "SELECT COUNT(*) FROM pragma_table_info('features') WHERE name = 'test_command'",
@@ -480,6 +461,26 @@ fn migrate_0011_features_test_command(conn: &Connection) -> rusqlite::Result<()>
     if has_column == 0 {
         conn.execute_batch("ALTER TABLE features ADD COLUMN test_command TEXT;")?;
     }
+    Ok(())
+}
+
+/// Adds the `symbol_fingerprints` table (per-function MinHash for near-clone
+/// detection). Idempotent via `IF NOT EXISTS`; existing indexes get the table
+/// empty and populate it on the next `codesage index`. `fp` is a fixed
+/// 512-byte BLOB (64 little-endian u64).
+fn migrate_0012_symbol_fingerprints(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS symbol_fingerprints (
+             file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+             name TEXT NOT NULL,
+             kind TEXT NOT NULL,
+             line_start INTEGER NOT NULL,
+             line_end INTEGER NOT NULL,
+             leaf_count INTEGER NOT NULL,
+             fp BLOB NOT NULL CHECK (length(fp) = 512)
+         );
+         CREATE INDEX IF NOT EXISTS idx_symfp_file ON symbol_fingerprints(file_id);",
+    )?;
     Ok(())
 }
 

--- a/crates/storage/src/schema.rs
+++ b/crates/storage/src/schema.rs
@@ -33,6 +33,21 @@ CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
 CREATE INDEX IF NOT EXISTS idx_symbols_qualified ON symbols(qualified_name);
 CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(file_id);
 
+-- One MinHash fingerprint per function/method definition, for near-clone
+-- (SIMILAR_TO) detection. `fp` is 64 little-endian u64 (512 bytes). Rebuilt
+-- per file on reindex, same lifecycle as `symbols`.
+CREATE TABLE IF NOT EXISTS symbol_fingerprints (
+    file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    line_start INTEGER NOT NULL,
+    line_end INTEGER NOT NULL,
+    leaf_count INTEGER NOT NULL,
+    fp BLOB NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_symfp_file ON symbol_fingerprints(file_id);
+
 CREATE TABLE IF NOT EXISTS refs (
     id INTEGER PRIMARY KEY,
     from_file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
@@ -325,6 +340,7 @@ const MIGRATIONS: &[(&str, MigrationUp)] = &[
         "0011_features_test_command",
         migrate_0011_features_test_command,
     ),
+    ("0012_symbol_fingerprints", migrate_0012_symbol_fingerprints),
 ];
 
 fn run_migrations(conn: &Connection) -> rusqlite::Result<()> {
@@ -436,6 +452,25 @@ fn migrate_0010_files_boundaries_derived_at(conn: &Connection) -> rusqlite::Resu
 /// change as the project's package-manager / lockfile evolves, so they
 /// must not destabilize feature identity. Existing rows default to NULL
 /// and get populated on the next `codesage index` mapper pass.
+/// Adds the `symbol_fingerprints` table (per-function MinHash for near-clone
+/// detection). Idempotent via `IF NOT EXISTS`; existing indexes get the table
+/// empty and populate it on the next `codesage index`.
+fn migrate_0012_symbol_fingerprints(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS symbol_fingerprints (
+             file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+             name TEXT NOT NULL,
+             kind TEXT NOT NULL,
+             line_start INTEGER NOT NULL,
+             line_end INTEGER NOT NULL,
+             leaf_count INTEGER NOT NULL,
+             fp BLOB NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS idx_symfp_file ON symbol_fingerprints(file_id);",
+    )?;
+    Ok(())
+}
+
 fn migrate_0011_features_test_command(conn: &Connection) -> rusqlite::Result<()> {
     let has_column: i64 = conn.query_row(
         "SELECT COUNT(*) FROM pragma_table_info('features') WHERE name = 'test_command'",

--- a/crates/storage/tests/schema_migration_test.rs
+++ b/crates/storage/tests/schema_migration_test.rs
@@ -202,6 +202,7 @@ fn fresh_db_records_migrations_exactly_once() {
         "0009_feature_tables",
         "0010_files_boundaries_derived_at",
         "0011_features_test_command",
+        "0012_symbol_fingerprints",
     ] {
         let count: i64 = conn
             .query_row(
@@ -213,13 +214,13 @@ fn fresh_db_records_migrations_exactly_once() {
         assert_eq!(count, 1, "{migration} recorded on fresh DB");
     }
 
-    // Running init_db again must be a no-op: count stays at 11.
+    // Running init_db again must be a no-op: count stays at 12.
     init_db(&conn).expect("second init_db");
     let count_after: i64 = conn
         .query_row("SELECT COUNT(*) FROM schema_migrations", [], |r| r.get(0))
         .unwrap();
     assert_eq!(
-        count_after, 11,
+        count_after, 12,
         "second init_db must not re-apply migrations"
     );
 }
@@ -252,6 +253,7 @@ fn legacy_db_records_migration_after_upgrade() {
         "0009_feature_tables",
         "0010_files_boundaries_derived_at",
         "0011_features_test_command",
+        "0012_symbol_fingerprints",
     ] {
         let count: i64 = conn
             .query_row(


### PR DESCRIPTION
## What
Adds `find_similar` — near-clone detection for functions and methods.

## Why
CodeSage had no way to answer "where else does this code shape exist?" — the question behind fixing copy-paste in every copy, spotting divergent forks of a helper, and catching duplication in review. It's the one capability the codebase-memory-mcp comparison flagged as genuinely absent.

## How
MinHash (K=64) over AST node-kind trigrams per function, so matching is on code *shape* — identifiers and literals are ignored. LSH banding keeps scoring at O(candidates) instead of O(n²). Fingerprints live in a `symbol_fingerprints` table (migration `0012`), written during the structural index pass and dropped on file re-upsert, the same lifecycle as `symbols`. `find_similar` builds the LSH index at query time and ranks by Jaccard; test files are excluded from candidates.

## Surface
- MCP tool `find_similar(project, name, min_jaccard?, limit?)` with `outputSchema`.
- CLI `codesage similar <name> [--min-jaccard 0.85] [--limit 20] [--json]`.

## Notes
- Requires a reindex (`codesage index`) to populate fingerprints; results are empty until then.
- Default `min_jaccard` 0.85.

## Verification
- Integration test `similar_test`: clone surfaced, unrelated function not, unknown symbol empty.
- End-to-end on this repo: `find_similar("unix_now")` returns `now_unix` (1.000); `is_safe_file` returns `is_safe_dir` (1.000).
- Full sanity-check green (fmt, clippy `-D warnings`, workspace tests).
