### PR TITLE
fix(review): same-file callee resolution + iterative fingerprint walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 - `impact_analysis` / `assess_risk` reverse-dependency resolution is now import-aware: a reference to an unqualified name is attributed only to the definition the caller imports, not to every same-named definition. Deflates inflated `dependent_files` blast radius for common names (framework lifecycle methods, shared utilities, trait-method implementations).
+- Import-aware resolution now also keeps same-file callers: a call to a name defined both locally and elsewhere resolves to the local definition (which has no import edge) instead of being dropped, so same-file callers are no longer lost from `impact_analysis` / `find_references`.
+- `find_similar` fingerprinting no longer recurses per AST depth; a pathologically deep source file can't overflow an indexer worker stack and abort `codesage index`.
 
 ## [0.12.0] - 2026-06-13
 

--- a/crates/graph/src/query.rs
+++ b/crates/graph/src/query.rs
@@ -2315,9 +2315,15 @@ fn resolve_callee_definitions(
     let filtered: Vec<Symbol> = candidates
         .into_iter()
         .filter(|s| {
-            import_refs
-                .iter()
-                .any(|imp| import_ref_targets_symbol(imp, to_name, s))
+            // A definition in the caller's own file is a valid target: a
+            // same-file call emits no import edge, so without this the local
+            // definition is filtered out and the reverse edge (read by
+            // `impact_analysis` / `assess_risk` through `references_for_symbol`)
+            // is lost. Mirrors the same-file preference in `resolve_def_summary`.
+            s.file_path == caller_file
+                || import_refs
+                    .iter()
+                    .any(|imp| import_ref_targets_symbol(imp, to_name, s))
         })
         .collect();
     Ok(filtered)
@@ -3430,6 +3436,44 @@ mod context_export_tests {
         assert!(
             refs.is_empty(),
             "qualified method without exact refs must not fall back to all bare `find` references: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn same_file_definition_resolves_when_name_is_ambiguous() {
+        // `helper` is defined in both a.rs and b.rs (ambiguous bare name). A call
+        // to `helper` from a.rs has no import edge for the local definition, so
+        // the import filter alone would drop it and lose the same-file reverse
+        // edge. The same-file fallback keeps a.rs's definition; the unimported
+        // homonym in b.rs is still excluded.
+        let db = Database::open_in_memory().unwrap();
+        let a = db
+            .upsert_file(&FileInfo {
+                path: "a.rs".to_string(),
+                language: Language::Rust,
+                content_hash: "a".to_string(),
+            })
+            .unwrap();
+        let b = db
+            .upsert_file(&FileInfo {
+                path: "b.rs".to_string(),
+                language: Language::Rust,
+                content_hash: "b".to_string(),
+            })
+            .unwrap();
+        db.insert_symbols(a, &[symbol("helper", "helper", "a.rs")])
+            .unwrap();
+        db.insert_symbols(b, &[symbol("helper", "helper", "b.rs")])
+            .unwrap();
+
+        let resolved = resolve_callee_definitions(&db, "a.rs", "helper").unwrap();
+        assert!(
+            resolved.iter().any(|s| s.file_path == "a.rs"),
+            "same-file ambiguous call must resolve to the local definition: {resolved:?}"
+        );
+        assert!(
+            !resolved.iter().any(|s| s.file_path == "b.rs"),
+            "the unimported homonym must not be resolved: {resolved:?}"
         );
     }
 

--- a/crates/parser/src/fingerprint.rs
+++ b/crates/parser/src/fingerprint.rs
@@ -65,16 +65,23 @@ const SEEDS: [u64; MINHASH_K] = {
 /// Pre-order walk of `node`, pushing each node's `kind_id` and counting leaves
 /// (childless nodes — the actual source tokens). Order is preserved so the
 /// trigram sequence reflects structure, not just a node-kind bag.
-fn collect_preorder(node: &Node, kinds: &mut Vec<u16>, leaves: &mut usize) {
-    kinds.push(node.kind_id());
-    let mut cursor = node.walk();
-    let mut had_child = false;
-    for child in node.children(&mut cursor) {
-        had_child = true;
-        collect_preorder(&child, kinds, leaves);
-    }
-    if !had_child {
-        *leaves += 1;
+fn collect_preorder(root: &Node, kinds: &mut Vec<u16>, leaves: &mut usize) {
+    // Explicit-stack pre-order walk rather than recursion: this runs inside the
+    // indexer's rayon workers (fixed, non-growable stacks), and a deeply nested
+    // AST (machine-generated code, long expression chains) would otherwise
+    // overflow the stack — an uncatchable SIGABRT that aborts the whole index
+    // run. Children are pushed in reverse so the leftmost is visited first,
+    // preserving pre-order (the trigram sequence depends on it).
+    let mut stack: Vec<Node> = vec![*root];
+    while let Some(node) = stack.pop() {
+        kinds.push(node.kind_id());
+        let mut cursor = node.walk();
+        let children: Vec<Node> = node.children(&mut cursor).collect();
+        if children.is_empty() {
+            *leaves += 1;
+        } else {
+            stack.extend(children.into_iter().rev());
+        }
     }
 }
 
@@ -198,6 +205,28 @@ mod tests {
     fn fps(src: &str, lang: Language) -> Vec<FunctionFingerprint> {
         let tree = parse_file(src.as_bytes(), lang).unwrap();
         file_fingerprints(&tree, src.as_bytes(), lang)
+    }
+
+    #[test]
+    fn deeply_nested_ast_does_not_overflow_the_stack() {
+        // A function body nested thousands of levels deep. The previous
+        // recursive `collect_preorder` used one native stack frame per level;
+        // on a small (rayon-worker-sized) stack that SIGABRTs and aborts the
+        // whole indexer. The iterative walk uses the heap, so it completes.
+        // Run on a deliberately small stack to make the regression observable.
+        let depth = 4000;
+        let mut body = String::from("1");
+        for _ in 0..depth {
+            body = format!("({body})");
+        }
+        let src = format!("fn deep() -> i32 {{ {body} }}\n");
+        let out = std::thread::Builder::new()
+            .stack_size(512 * 1024)
+            .spawn(move || fps(&src, Language::Rust).len())
+            .unwrap()
+            .join()
+            .unwrap();
+        assert_eq!(out, 1, "deeply nested function should still fingerprint");
     }
 
     #[test]


### PR DESCRIPTION
Fixes two bugs the codesage feature-slice review found in the just-merged `find_similar` / import-aware-resolution work.

## 1. Same-file callers dropped for ambiguous names (`query.rs`)
`resolve_callee_definitions` filtered ambiguous unqualified names by the caller's imports only. A call to a name defined **in its own file** emits no import edge, so the local definition was filtered out and the same-file reverse edge was lost — undercounting callers in `impact_analysis` / `find_references` and shrinking `assess_risk`'s `dependent_files` term. Fix: keep a candidate whose `file_path == caller_file`, mirroring the same-file preference already in `resolve_def_summary`. The unimported homonym in other files is still excluded.

## 2. Unbounded recursion in the fingerprint walk (`fingerprint.rs`)
`collect_preorder` recursed once per AST depth. It runs inside the indexer's rayon workers (fixed, non-growable stacks), so a pathologically deep source file (machine-generated code, long expression chains) could overflow the stack — an uncatchable SIGABRT that aborts the whole `codesage index` run. Replaced with an explicit-stack iterative pre-order walk (children pushed in reverse to preserve order).

## Tests
- `same_file_definition_resolves_when_name_is_ambiguous` — fails without the fix.
- `deeply_nested_ast_does_not_overflow_the_stack` — fingerprints a 4000-deep nested body on a 512 KB stack.

## Not a bug
The review also surfaced a recurring "watch filter ignores nested .gitignore" finding; verified already fixed at `discover.rs:240` (`add_nested_gitignores`, the 0.11.0 change). Marked resolved, no code change.

Full green: fmt, clippy `-D warnings`, workspace tests.
