### PR TITLE
deps: bump rmcp 1.8 -> 2.1 (Content -> ContentBlock migration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Changed
+- Upgrade the `rmcp` MCP SDK to 2.x (MCP 2025-11-25 spec model types).
+
 ### Security
 - Bump `crossbeam-epoch` to 0.9.20, clearing RUSTSEC-2026-0204 (invalid pointer dereference in `fmt::Pointer`).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ regex = "1"
 
 clap = { version = "4", features = ["derive"] }
 
-rmcp = { version = "1.7", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "2.1", features = ["server", "transport-io", "macros"] }
 tokio = { version = "1", features = ["full"] }
 schemars = "1.2"
 

--- a/crates/cli/src/mcp/mod.rs
+++ b/crates/cli/src/mcp/mod.rs
@@ -23,7 +23,7 @@ use codesage_protocol::{
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, tool::schema_for_type, wrapper::Parameters},
-    model::{CallToolResult, Content, Implementation, ServerInfo},
+    model::{CallToolResult, ContentBlock, Implementation, ServerInfo},
     tool, tool_handler, tool_router,
 };
 
@@ -83,7 +83,7 @@ impl CodeSageServer {
             Ok(result) => result,
             Err(join_err) => {
                 tracing::error!(error = %join_err, "MCP tool handler panicked");
-                CallToolResult::error(vec![Content::text(format!(
+                CallToolResult::error(vec![ContentBlock::text(format!(
                     "internal error: the tool handler panicked ({join_err}); see the daemon log"
                 ))])
             }

--- a/crates/cli/src/mcp/render.rs
+++ b/crates/cli/src/mcp/render.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use super::CodeSageServer;
 
@@ -82,7 +82,7 @@ impl CodeSageServer {
         );
         let existing = std::mem::take(&mut result.content);
         let mut content = Vec::with_capacity(existing.len() + 1);
-        content.push(Content::text(banner));
+        content.push(ContentBlock::text(banner));
         content.extend(existing);
         result.content = content;
         result
@@ -186,10 +186,10 @@ fn render_with_budget<T: serde::Serialize>(
             let mut result = CallToolResult::structured(structured);
             // `CallToolResult::structured` defaults content to a compact
             // `value.to_string()`; replace with pretty JSON for transcript use.
-            result.content = vec![Content::text(text)];
+            result.content = vec![ContentBlock::text(text)];
             result
         }
-        Err(e) => CallToolResult::error(vec![Content::text(format!("Error: {e:#}"))]),
+        Err(e) => CallToolResult::error(vec![ContentBlock::text(format!("Error: {e:#}"))]),
     }
 }
 


### PR DESCRIPTION
Supersedes #34 (Dependabot bumped the version but the v2 API break failed CI).

rmcp 2.0 realigned model types to the MCP 2025-11-25 spec, renaming `Content` to `ContentBlock`. Only two call sites in `crates/cli/src/mcp/` reference the type; renamed both. No wire-format change.

## Verification
- `bash scripts/sanity-check.sh` (fmt + clippy `-D warnings` + full test suite + regression tests): green.
- Live smoke on the rebuilt binary via `codesage mcp --direct`:
  - `initialize` negotiates protocolVersion `2025-06-18`, server `codesage`.
  - `tools/list` returns 19 tools.
  - `tools/call find_symbol` returns a text `ContentBlock` + `structuredContent` object, `isError: false`.

The v2 changelog also carries security fixes (OAuth resource spoofing, redirect header leaks) that ride along with this bump.